### PR TITLE
build out support for timestamp notation in set

### DIFF
--- a/lib/Prometheus/Tiny.pm
+++ b/lib/Prometheus/Tiny.pm
@@ -179,9 +179,9 @@ L<Prometheus::Tiny::Shared> for that!
 
 =head2 set
 
-    $prom->set($name, $value, { labels })
+    $prom->set($name, $value, { labels }, [timestamp])
 
-Set the value for the named metric. The labels hashref is optional.
+Set the value for the named metric. The labels hashref is optional. The timestamp (milliseconds since epoch) is optional, but requires labels to be provided to use. An empty hashref will work in the case of no labels.
 
 =head2 add
 

--- a/lib/Prometheus/Tiny.pm
+++ b/lib/Prometheus/Tiny.pm
@@ -27,8 +27,10 @@ sub _format_labels {
 }
 
 sub set {
-  my ($self, $name, $value, $labels) = @_;
+  my ($self, $name, $value, $labels, $timestamp) = @_;
   $self->{metrics}{$name}{$self->_format_labels($labels)} = $value;
+  $self->{meta}{$name}{timestamp} = $timestamp
+  	if $timestamp;
   return;
 }
 
@@ -82,9 +84,10 @@ sub format {
       (defined $self->{meta}{$name}{type} ?
         ("# TYPE $name $self->{meta}{$name}{type}\n") : ()),
       (map {
+	  	my $ts = $self->{meta}{$name}{timestamp} ? ' '.$self->{meta}{$name}{timestamp} : '';
         $_ ?
-          join '', $name, '{', $_, '} ', $self->{metrics}{$name}{$_}, "\n" :
-          join '', $name, ' ', $self->{metrics}{$name}{$_}, "\n"
+          join '', $name, '{', $_, '} ', $self->{metrics}{$name}{$_}, $ts, "\n" :
+          join '', $name, ' ', $self->{metrics}{$name}{$_}, $ts, "\n"
       } sort {
         $name =~ m/_bucket$/ ?
           do {

--- a/lib/Prometheus/Tiny.pm
+++ b/lib/Prometheus/Tiny.pm
@@ -28,8 +28,9 @@ sub _format_labels {
 
 sub set {
   my ($self, $name, $value, $labels, $timestamp) = @_;
-  $self->{metrics}{$name}{$self->_format_labels($labels)} = $value;
-  $self->{meta}{$name}{timestamp} = $timestamp
+  my $f_label = $self->_format_labels($labels);
+  $self->{metrics}{$name}{$f_label} = $value;
+  $self->{meta}{timestamp}{$name}{$f_label} = $timestamp
   	if $timestamp;
   return;
 }
@@ -84,7 +85,7 @@ sub format {
       (defined $self->{meta}{$name}{type} ?
         ("# TYPE $name $self->{meta}{$name}{type}\n") : ()),
       (map {
-	  	my $ts = $self->{meta}{$name}{timestamp} ? ' '.$self->{meta}{$name}{timestamp} : '';
+	  	my $ts = $self->{meta}{timestamp}{$name}{$_} ? ' '.$self->{meta}{timestamp}{$name}{$_} : '';
         $_ ?
           join '', $name, '{', $_, '} ', $self->{metrics}{$name}{$_}, $ts, "\n" :
           join '', $name, ' ', $self->{metrics}{$name}{$_}, $ts, "\n"

--- a/t/10-set.t
+++ b/t/10-set.t
@@ -39,4 +39,31 @@ some_metric 8
 EOF
 }
 
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, {}, 1234);
+  is $p->format, <<EOF, 'single metric with timestamp formatted correctly';
+some_metric 5 1234
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, {}, 2345);
+  $p->set('other_metric', 10, {}, 1234);
+  is $p->format, <<EOF, 'multiple metrics with timestamp formatted correctly';
+other_metric 10 1234
+some_metric 5 2345
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 3, {}, 1234);
+  $p->set('some_metric', 8, {}, 2345);
+  is $p->format, <<EOF, 'single metric with timestamp is overwritten correctly';
+some_metric 8 2345
+EOF
+}
+
 done_testing;

--- a/t/15-labels.t
+++ b/t/15-labels.t
@@ -93,7 +93,7 @@ EOF
 other_metric{other_label="bbb"} 10 4567
 some_metric{some_label="aaa"} 5 1234
 some_metric{some_label="bbb"} 5 2345
-some_metric{some_label="ccc"} 6 3456
+some_metric{some_label="ccc"} 5 3456
 EOF
 }
 

--- a/t/15-labels.t
+++ b/t/15-labels.t
@@ -64,4 +64,33 @@ some_metric{some_label="bbb"} 8
 EOF
 }
 
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, { some_label => 'aaa' }, 1234);
+  is $p->format, <<EOF, 'single metric with label and timestamp formatted correctly';
+some_metric{some_label="aaa"} 5 1234
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, { some_label => "aaa" }, 1234);
+  $p->set('other_metric', 10, { other_label => "bbb" }, 2345);
+  is $p->format, <<EOF, 'multiple metrics with labels and timestamps formatted correctly';
+other_metric{other_label="bbb"} 10 2345
+some_metric{some_label="aaa"} 5 1234
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, { some_label => "aaa" }, 1234);
+  $p->set('other_metric', 10);
+  is $p->format, <<EOF, 'multiple metrics with mixed labels formatted correctly';
+other_metric 10
+some_metric{some_label="aaa"} 5 1234
+EOF
+}
+
 done_testing;

--- a/t/15-labels.t
+++ b/t/15-labels.t
@@ -86,6 +86,20 @@ EOF
 {
   my $p = Prometheus::Tiny->new;
   $p->set('some_metric', 5, { some_label => "aaa" }, 1234);
+  $p->set('some_metric', 5, { some_label => "bbb" }, 2345);
+  $p->set('some_metric', 5, { some_label => "ccc" }, 3456);
+  $p->set('other_metric', 10, { other_label => "bbb" }, 4567);
+  is $p->format, <<EOF, 'multiple metrics with labels and timestamps formatted correctly';
+other_metric{other_label="bbb"} 10 4567
+some_metric{some_label="aaa"} 5 1234
+some_metric{some_label="bbb"} 5 2345
+some_metric{some_label="ccc"} 6 3456
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 5, { some_label => "aaa" }, 1234);
   $p->set('other_metric', 10);
   is $p->format, <<EOF, 'multiple metrics with mixed labels formatted correctly';
 other_metric 10


### PR DESCRIPTION
fixes:#5

Doc's make note of an optional 4th param to be a timestamp in
milliseconds. This change adds support for this value to be provided via set.

https://github.com/prometheus/docs/blob/c02c703/content/docs/instrumenting/exposition_formats.md