### PR TITLE
Implement default_labels setting

### DIFF
--- a/lib/Prometheus/Tiny.pm
+++ b/lib/Prometheus/Tiny.pm
@@ -16,21 +16,29 @@ my $DEFAULT_BUCKETS = [
 ];
 
 sub new {
-  my ($class) = @_;
+  my ($class, %arg) = @_;
+  my %defaults = $arg{default_labels} ? %{$arg{default_labels}} : ();
   return bless {
     metrics => {},
     meta => {},
+    default_labels => \%defaults,
   }, $class;
 }
 
 sub _format_labels {
   my ($self, $labels) = @_;
+
+  # Avoid copying the labels hash unless we need to add defaults.
+  my $to_format = $self->{default_labels}
+                ? { %{$self->{default_labels}}, %{$labels || {}} }
+                : $labels;
+
   join ',', map {
-    my $lv = $labels->{$_};
+    my $lv = $to_format->{$_};
     $lv =~ s/(["\\])/\\$1/sg;
     $lv =~ s/\n/\\n/sg;
     qq{$_="$lv"}
-  } sort keys %$labels;
+  } sort keys %$to_format;
 }
 
 sub set {
@@ -222,7 +230,12 @@ L<Prometheus::Tiny::Shared> for that!
 
 =head2 new
 
-    my $prom = Prometheus::Tiny->new
+    my $prom = Prometheus::Tiny->new;
+    my $prom = Promethus::Tiny->new(default_labels => { my_label => "frob" });
+
+If you pass a C<default_labels> key to the constructor, these labels will be
+included in every metric created on this object.
+
 
 =head1 METHODS
 

--- a/t/15-labels.t
+++ b/t/15-labels.t
@@ -121,4 +121,34 @@ some_metric{some_label="aaa"} 5 1234
 EOF
 }
 
+{
+  my $p = Prometheus::Tiny->new(default_labels => { default_label => 'frob' });
+  $p->set('some_metric', 10);
+  is $p->format, <<EOF, 'metric with no label gets single default label';
+some_metric{default_label="frob"} 10
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new(default_labels => {
+    default_one => 'whiz',
+    default_two => 'bang',
+  });
+  $p->set('some_metric', 10);
+  is $p->format, <<EOF, 'metric with no label gets all default labels';
+some_metric{default_one="whiz",default_two="bang"} 10
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new(default_labels => {
+    default_one => 'whiz',
+    default_two => 'bang',
+  });
+  $p->set('some_metric', 10, { other => 'pow', default_two => 'blam' });
+  is $p->format, <<EOF, 'we can overwrite default labels if we want';
+some_metric{default_one="whiz",default_two="blam",other="pow"} 10
+EOF
+}
+
 done_testing;


### PR DESCRIPTION
If you pass `default_labels => { my_label => 'frob' }` to the
initializer, we'll now include it in every metric you use. This gets
included even if you don't include labels in your metric calls, and you
can overwrite the default by providing it during a setting call.