### PR TITLE
Try to protect against setting or adding non-values to metrics

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+- Warn and handle attempts to set or add non-numbers
 
 0.009     2021-12-07 16:46:15+11:00 Australia/Melbourne
 - Add default_labels parameter (thanks, Michael McClimon!)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ my %WriteMakefileArgs = (
   "NAME" => "Prometheus::Tiny",
   "PREREQ_PM" => {
     "Carp" => 0,
+    "Scalar::Util" => 0,
     "strict" => 0,
     "warnings" => 0
   },
@@ -24,7 +25,8 @@ my %WriteMakefileArgs = (
     "HTTP::Request::Common" => 0,
     "Plack::Test" => 0,
     "Test::Exception" => 0,
-    "Test::More" => 0
+    "Test::More" => 0,
+    "Test::Warn" => 0
   },
   "VERSION" => "0.009",
   "test" => {
@@ -37,8 +39,10 @@ my %FallbackPrereqs = (
   "Carp" => 0,
   "HTTP::Request::Common" => 0,
   "Plack::Test" => 0,
+  "Scalar::Util" => 0,
   "Test::Exception" => 0,
   "Test::More" => 0,
+  "Test::Warn" => 0,
   "strict" => 0,
   "warnings" => 0
 );

--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ included in every metric created on this object.
 
 Set the value for the named metric. The labels hashref is optional. The timestamp (milliseconds since epoch) is optional, but requires labels to be provided to use. An empty hashref will work in the case of no labels.
 
+Trying to set a metric to a non-numeric value will emit a warning and the metric will be set to zero.
+
 ## add
 
     $prom->add($name, $amount, { labels })
 
 Add the given amount to the already-stored value (or 0 if it doesn't exist). The labels hashref is optional.
+
+Trying to add a non-numeric value to a metric will emit a warning and 0 will be added instead (this will still create the metric if it didn't exist, and will update timestamps etc).
 
 ## inc
 

--- a/lib/Prometheus/Tiny.pm
+++ b/lib/Prometheus/Tiny.pm
@@ -5,7 +5,8 @@ package Prometheus::Tiny;
 use warnings;
 use strict;
 
-use Carp qw(croak);
+use Carp qw(croak carp);
+use Scalar::Util qw(looks_like_number);
 
 my $DEFAULT_BUCKETS = [
                0.005,
@@ -43,6 +44,10 @@ sub _format_labels {
 
 sub set {
   my ($self, $name, $value, $labels, $timestamp) = @_;
+  unless (looks_like_number $value) {
+    carp "setting '$name' to non-numeric value, using 0 instead";
+    $value = 0;
+  }
   my $f_label = $self->_format_labels($labels);
   $self->{metrics}{$name}{$f_label} = [ $value, $timestamp ];
   return;
@@ -50,6 +55,10 @@ sub set {
 
 sub add {
   my ($self, $name, $value, $labels) = @_;
+  unless (looks_like_number $value) {
+    carp "adjusting '$name' by non-numeric value, adding 0 instead";
+    $value = 0;
+  }
   $self->{metrics}{$name}{$self->_format_labels($labels)}->[0] += $value;
   return;
 }
@@ -245,11 +254,15 @@ included in every metric created on this object.
 
 Set the value for the named metric. The labels hashref is optional. The timestamp (milliseconds since epoch) is optional, but requires labels to be provided to use. An empty hashref will work in the case of no labels.
 
+Trying to set a metric to a non-numeric value will emit a warning and the metric will be set to zero.
+
 =head2 add
 
     $prom->add($name, $amount, { labels })
 
 Add the given amount to the already-stored value (or 0 if it doesn't exist). The labels hashref is optional.
+
+Trying to add a non-numeric value to a metric will emit a warning and 0 will be added instead (this will still create the metric if it didn't exist, and will update timestamps etc).
 
 =head2 inc
 

--- a/t/50-warn-undef.t
+++ b/t/50-warn-undef.t
@@ -1,0 +1,35 @@
+#!perl
+
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warn;
+
+use Prometheus::Tiny;
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 10);
+  warning_like
+    { $p->set('some_metric') }
+    qr/setting '.+' to non-numeric value, using 0 instead/,
+    'setting undef value emits a warning';
+  is $p->format, <<EOF, 'set metric undef formatted correctly';
+some_metric 0
+EOF
+}
+
+{
+  my $p = Prometheus::Tiny->new;
+  $p->set('some_metric', 10);
+  warning_like
+    { $p->add('some_metric') }
+    qr/adjusting '.+' by non-numeric value, adding 0 instead/,
+    'adding undef value emits a warning';
+  is $p->format, <<EOF, 'add metric undef formatted correctly';
+some_metric 10
+EOF
+}
+
+done_testing;


### PR DESCRIPTION
Its not hard in metrics proxy/bridge code to accidentally pass through
an undef as a metric value because something has happened at the remote
metrics source.

This is definitely a bug in the client code, which should be trying to
sanitise incoming data, but we can at least try to help make these bugs
easier to see by warning for the simple cases, and not breaking the
metrics output (leading to failed scrapes).